### PR TITLE
Point at latest (not archived version)

### DIFF
--- a/docs/how_to_use.rst
+++ b/docs/how_to_use.rst
@@ -3,4 +3,4 @@ How to use
 
 For some examples on how to use the library:
 
-* `https://github.com/hydroffice/hyo_bag/tree/master/examples <https://github.com/hydroffice/hyo_bag/tree/master/examples>`_
+* `https://github.com/hydroffice/hyo2_bag/tree/master/examples <https://github.com/hydroffice/hyo2_bag/tree/master/examples>`_


### PR DESCRIPTION
Just noticed the docs pointed at the previous, archived version of the examples.

Thanks for publishing this btw! 